### PR TITLE
Adding utf8 decode to exception response content.

### DIFF
--- a/coincheck_api/clients/api_client.py
+++ b/coincheck_api/clients/api_client.py
@@ -39,5 +39,5 @@ class ApiClient:
         else:
             raise CoinCheckApiException(
                 "API execute failure. response status_code={}, headers={}, body={}".format(
-                    response.status_code, response.headers, response.content
+                    response.status_code, response.headers, response.content.decode('utf8')
                 ))


### PR DESCRIPTION
Coincheck error messages might contain Japanese characters; adding a utf8 decode will allow them to be printed to the console for debugging.